### PR TITLE
Allow using requested formats

### DIFF
--- a/youtube-dl.lua
+++ b/youtube-dl.lua
@@ -44,7 +44,7 @@ function parse()
       end
       -- prefer audio and video
       for key, format in pairs(json.formats) do
-        if format.vcodec and format.acodec then
+        if format.vcodec ~= (nil or "none") and format.acodec ~= (nil or "none") then
           outurl = format.url
         end
       end


### PR DESCRIPTION
For some videos (e.g. https://www.youtube.com/watch?v=8q8LsYbDCmM), the matched format points to a broken server or something. Ideally, we would check if the stream works first and choose a different one otherwise but that would be a lot of work. And youtube-dl seems to select a “best” working format somehow anyway so we might as well use that.

Though, for me, it often comes as two separate streams – one for audio and another for video, so we need to handle that case using `input-slave`.
