### PR TITLE
Add quotes surrounding URL in io.popen

### DIFF
--- a/youtube-dl.lua
+++ b/youtube-dl.lua
@@ -30,7 +30,7 @@ function parse()
 
   --checks if youtube-dl exists, else download the right file or update it
 
-  local file = assert(io.popen('youtube-dl -j --flat-playlist '..url, 'r'))  --run youtube-dl in json mode
+  local file = assert(io.popen('youtube-dl -j --flat-playlist "'..url..'"', 'r'))  --run youtube-dl in json mode
   local tracks = {}
   while true do
     local output = file:read('*l')


### PR DESCRIPTION
This fixes a lot of issues caused by `&` and other shell-related characters in the URL.